### PR TITLE
Feat/Implementando o efeito Typewriter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+\node_modules
+.docusaurus

--- a/src/components/Homepage/index.js
+++ b/src/components/Homepage/index.js
@@ -1,16 +1,28 @@
-import React from 'react';
-import styles from './styles.module.css';
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import TypeWriter from "typewriter-effect";
+import React from "react";
+import styles from "./styles.module.css";
+import Typewriter from "typewriter-effect";
 
 export default function Homepage() {
-    return (
-        <div className={styles.headerContainer}>            
-            <div className={styles.headerBody}>
-                <div className={styles.headerTitleContainer}>
-                    <div><h2>Aprenda com a comunidade.</h2></div>
-                </div>
-            </div>
+  return (
+    <div className={styles.headerContainer}>
+      <h2>
+        <span className="sr-only">Aprenda com a comunidade</span>
+        <div aria-disabled="true">
+          <Typewriter
+            options={{
+              autoStart: true,
+              loop: true,
+            }}
+            onInit={(typewriter) => {
+              typewriter
+                .typeString("Aprenda com a comunidade")
+                .pauseFor(600)
+                .deleteAll()
+                .start();
+            }}
+          />
         </div>
-    );
+      </h2>
+    </div>
+  );
 }

--- a/src/components/Homepage/styles.module.css
+++ b/src/components/Homepage/styles.module.css
@@ -1,57 +1,38 @@
-.headerContainer {
-    margin: 2%;
-}
-
-.headerBody {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-content: space-around;
-}
-
-.headerTitleContainer {
-    display: inline-flex;
-    align-items: row;
-    align-self: center;
-    justify-self: center;
-}
-
-.headerTitleContainer h2 {
-    margin-right: 30px;
-    font-family: 'Roboto';
-    font-weight: 700;
-    font-size: 40px;
-    color: #fff;
+.headerContainer h2 {
+  font-family: "Roboto";
+  font-weight: 700;
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  color: #fff;
+  text-align: center;
+  margin: 0;
 }
 
 .headerTitle {
-    text-align: left;
+  text-align: left;
 }
 
 .headerTitle h1 {
-    font-family: 'Roboto';
-    font-weight: 700;
-    font-size: 40px;
-    color: var(--ifm-color-footer-button);
+  font-family: "Roboto";
+  font-weight: 700;
+  font-size: 40px;
+  color: var(--ifm-color-footer-button);
 }
 
 .headerTitle h3 {
-    font-size: 30px;
+  font-size: 30px;
 }
 
 .headerTypeWriter {
-    font-family: 'Roboto';
-    font-weight: 700;
-    font-size: 40px;
-    align-self: center;
-    justify-self: center;
-    width: 700px;
-    height: -700px;
-    color: #fff
+  font-family: "Roboto";
+  font-weight: 700;
+  font-size: 40px;
+  align-self: center;
+  justify-self: center;
+  width: 700px;
+  height: -700px;
+  color: #fff;
 }
 
 .headerLogo {
-    margin-left: 132px;
+  margin-left: 132px;
 }
-
-

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,17 +1,17 @@
 @font-face {
-  font-family: 'Poppins';
-  src: url('../../static/fonts/Poppins-Bold.ttf') format('truetype');
+  font-family: "Poppins";
+  src: url("../../static/fonts/Poppins-Bold.ttf") format("truetype");
   font-weight: 500;
 }
 
 @font-face {
-  font-family: 'Open Sans';
-  src: url('../../static//fonts/OpenSans-Regular.ttf') format('truetype');
+  font-family: "Open Sans";
+  src: url("../../static//fonts/OpenSans-Regular.ttf") format("truetype");
 }
 
 @font-face {
-  font-family: 'Roboto';
-  src: url('../../static//fonts/Roboto-Regular.ttf') format('truetype');
+  font-family: "Roboto";
+  src: url("../../static//fonts/Roboto-Regular.ttf") format("truetype");
 }
 
 :root {
@@ -22,36 +22,36 @@
   --ifm-color-primary-light: #0f314d;
   --ifm-color-primary-lighter: #0f314d;
   --ifm-color-primary-lightest: #0f314d;
-  --ifm-color-card-background: #F5F5F5;
-  --ifm-color-card-hover: #FFFFFF;
-  --ifm-color-card-border: #D9D9D9;
-  --ifm-color-card-border-hover: #F7F7F7;
+  --ifm-color-card-background: #f5f5f5;
+  --ifm-color-card-hover: #ffffff;
+  --ifm-color-card-border: #d9d9d9;
+  --ifm-color-card-border-hover: #f7f7f7;
   --ifm-color-card-shadow: #989898;
   --ifm-color-black: #000000;
-  --ifm-color-white: #FFFFFF;
-  --ifm-background-color: #F5F5F5;
-  --ifm-color-title: #FFFFFF;
+  --ifm-color-white: #ffffff;
+  --ifm-background-color: #f5f5f5;
+  --ifm-color-title: #ffffff;
   --ifm-color-description: #240a0a;
   --ifm-color-text-search-bar: #000;
-  --ifm-color-banner-title: #FFFFFF;
-  --ifm-color-navbar-text: #111A2F;
+  --ifm-color-banner-title: #ffffff;
+  --ifm-color-navbar-text: #111a2f;
   --ifm-color-login-card: #f5f5f5;
   --ifm-color-login-background: #2246be;
   --ifm-color-footer-button: #0021de;
-  --ifm-navbar-background-color: #FFFFFF;
-  --ifm-link-color: #0184DE;
+  --ifm-navbar-background-color: #ffffff;
+  --ifm-link-color: #0184de;
 }
 
-[data-theme='dark'] {
+[data-theme="dark"] {
   --ifm-color-primary: #2273be;
   --ifm-color-primary-dark: #09319e;
   --ifm-color-primary-darker: #09319e;
   --ifm-color-primary-darkest: #09319e;
-  --ifm-color-primary-light: #FFFFFF;
-  --ifm-color-primary-lighter: #FFFFFF;
-  --ifm-color-primary-lightest: #060E1D;
-  --ifm-color-card-background: #060E1D;
-  --ifm-color-card-border-hover: #FFFFFF;
+  --ifm-color-primary-light: #ffffff;
+  --ifm-color-primary-lighter: #ffffff;
+  --ifm-color-primary-lightest: #060e1d;
+  --ifm-color-card-background: #060e1d;
+  --ifm-color-card-border-hover: #ffffff;
   --ifm-color-card-hover: #f9f9f91e;
   --ifm-color-card-border: #818181;
   --ifm-color-card-shadow: #6a6a6a;
@@ -59,28 +59,35 @@
   --ifm-color-title: #f7f9fdce;
   --ifm-color-description: #e5e5e5;
   --ifm-color-text-search-bar: #fff;
-  --ifm-color-banner-title: #FFFFFF;
-  --ifm-color-navbar-text: #F9F9F9;
+  --ifm-color-banner-title: #ffffff;
+  --ifm-color-navbar-text: #f9f9f9;
   --ifm-color-login-card: #f5f5f5;
-  --ifm-color-login-background: #2D3549;
+  --ifm-color-login-background: #2d3549;
   --ifm-color-footer-button: #0021de;
   --ifm-navbar-background-color: #000000;
-  --ifm-link-color: #0184DE;
+  --ifm-link-color: #0184de;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
-html[data-theme='dark'] {
-  --ifm-background-color: #1B1B1D;
-  --ifm-background-surface-color: #1B1B1D;
+html[data-theme="dark"] {
+  --ifm-background-color: #1b1b1d;
+  --ifm-background-surface-color: #1b1b1d;
 }
 
-h1, h2, h3, h4, h5 {
-  font-family: 'Poppins';
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-family: "Poppins";
 }
 
-p, a, li, code {
-  font-family: 'Open Sans';
+p,
+a,
+li,
+code {
+  font-family: "Open Sans";
 }
 
 .homepage {
@@ -89,18 +96,16 @@ p, a, li, code {
   background-position: center center;
   background-size: cover;
   background-color: var(--ifm-color-primary);
-}
-
-.homepage-container {
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
   height: 100%;
+  padding: 2rem;
 }
 
 .navbar-text {
-  font-family: 'Poppins';
+  font-family: "Poppins";
   font-weight: 400;
   font-size: 16px;
   color: var(--ifm-color-navbar-text);
@@ -128,11 +133,11 @@ p, a, li, code {
 .logout-button {
   margin-left: 15px;
   cursor: pointer;
-  font-family: 'Poppins';
+  font-family: "Poppins";
   color: var(--ifm-color-navbar-text);
 }
 
-:root { 
+:root {
   --doc-sidebar-width: 250px !important;
 }
 
@@ -203,7 +208,7 @@ p, a, li, code {
   background-color: var(--ifm-color-primary-lightest);
   background-size: cover;
   margin: 8%;
-  font-size:larger;
+  font-size: larger;
   color: var(--ifm-color-card-border-hover);
   height: 500px;
 }
@@ -227,7 +232,7 @@ p, a, li, code {
   --docsearch-text-color: var(--ifm-color-text-search-bar);
 }
 
-.space_c1nM h2{
+.space_c1nM h2 {
   border-radius: 0.25rem;
   border: 1px solid;
   border-inline-start-width: 1px;
@@ -235,4 +240,18 @@ p, a, li, code {
 
 .cards_SFyd {
   --ifm-color-primary-lightest: #ee190a;
+}
+
+.sr-only {
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+  white-space: nowrap !important;
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,15 +1,13 @@
-import React from 'react';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
-import Homepage from '@site/src/components/Homepage';
+import React from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Layout from "@theme/Layout";
+import HomepageFeatures from "@site/src/components/HomepageFeatures";
+import Homepage from "@site/src/components/Homepage";
 
 function HomepageHeader() {
   return (
-    <header className='homepage'>
-      <div className="homepage-container">
-        <Homepage />
-      </div>
+    <header className="homepage">
+      <Homepage />
     </header>
   );
 }
@@ -17,8 +15,7 @@ function HomepageHeader() {
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout
-      description="Aprenda sobre DevOps, de comunidade para comunidade">
+    <Layout description="Aprenda sobre DevOps, de comunidade para comunidade">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
## Objetivo
Implementar o efeito Typewriter de forma acessível

## Solução
- Utilizado a mesma lib que foi instalada previamente, a `typewriter-effect` já possuí um wrapper em React que foi utilizado.

- Foi criado um `<span>` com a classe `.sr-only` pra que essa seja lida corretamente por leitores de tela por possuir texto estático

- Foi criada uma div com `aria-disabled=true` pra servir de wrapper do elemento Typewriter pra que o texto dinâmico não seja lido por leitores de tela - a lib não herda atributos HTML nem possui a prop "as" pra customizar o elemento wrapper, por isso usei essa abordagem

- Haviam alguns containers que foram removidos, eliminando redundância sem alterar o layout

- Foi implementado fonte com tipografia fluída usando `clamp()` - [link para referência](https://www.smashingmagazine.com/2022/01/modern-fluid-typography-css-clamp/#fluid-typography-with-css-clamp)

- O prettier fez algumas alterações de estilo (aspas, espaços, etc). Caso você goste desse padrão, podemos definir um arquivo de configuração pro prettier/eslint via [.prettierrc](https://prettier.io/docs/en/configuration.html), caso contrário, posso removê-las/ alterá-las


Parabéns pelo trabalho! 🚀 